### PR TITLE
Extend invoice header with invoice template in create invoice request.

### DIFF
--- a/SzamlazzHuSDK/Model/InvoiceHeader.cs
+++ b/SzamlazzHuSDK/Model/InvoiceHeader.cs
@@ -26,6 +26,7 @@ namespace SzamlazzHu
         public string InvoiceNumberPrefix { get; set; }
         public string InvoiceType { get; set; }
         public bool Paid { get; set; } = false;
+        public string InvoiceTemplate { get; set; }
 
         private static string GetEnumDescription(Enum value)
         {

--- a/SzamlazzHuSDK/Xml/XmlParser.cs
+++ b/SzamlazzHuSDK/Xml/XmlParser.cs
@@ -123,7 +123,8 @@ namespace SzamlazzHu
                 Comment = GetString(node, "megjegyzes"),
                 FeeCollection = GetString(node, "tipus").ToLower() == "d",
                 InvoiceNumberPrefix = GetPrefix(GetString(node, "szamlaszam")),
-                OrderNumber = GetString(node, "rendelesszam")
+                OrderNumber = GetString(node, "rendelesszam"),
+                InvoiceTemplate = GetString(node, "szamlaSablon")
             };
         }
 

--- a/SzamlazzHuSDK/createInvoiceRequest.sbn
+++ b/SzamlazzHuSDK/createInvoiceRequest.sbn
@@ -68,6 +68,8 @@
         <szamlaszamElotag>{{ request.header.invoice_number_prefix }}</szamlaszamElotag>
         <!-- One of the prefixes from the invoice pad menu  -->
         <fizetve>{{ request.header.paid }}</fizetve>
+		<!-- Codomain: 'SzlaMost' | 'SzlaAlap' | 'SzlaNoEnv' | 'Szla8cm' | 'SzlaTomb' | 'SzlaFuvarlevelesAlap'-->
+		<szamlaSablon>{{ request.header.invoice_template }}</szamlaSablon>
     </fejlec>
     <elado>
         <!-- Details of the merchant-->

--- a/SzamlazzHuTest/InvoiceTest.cs
+++ b/SzamlazzHuTest/InvoiceTest.cs
@@ -137,6 +137,7 @@ namespace SzamlazzHuTest
             request.Header.CompletionDate = new DateTime(2020, 1, 20);
             request.Header.DueDate = new DateTime(2020, 1, 20);
             request.Header.Comment = "Invoce comment";
+            request.Header.InvoiceTemplate = "Szla8cm";
             request.Header.PaymentType = "átutalás";
             request.Seller.BankName = "BB";
             request.Seller.BankAccount = "11111111-22222222-33333333";

--- a/SzamlazzHuTest/InvoiceTest.cs
+++ b/SzamlazzHuTest/InvoiceTest.cs
@@ -78,6 +78,7 @@ namespace SzamlazzHuTest
             request.Header.CompletionDate = DateTime.Now;
             request.Header.DueDate = DateTime.Now;
             request.Header.FeeCollection = true;
+            request.Header.InvoiceTemplate = "Szla8cm";
             var response = await api.CreateInvoice(request);
             Assert.IsTrue(response.Success, response.ErrorMessage);
             var getInvoiceRequest = new GetInvoiceRequest();
@@ -96,6 +97,9 @@ namespace SzamlazzHuTest
             Assert.AreEqual(request.Header.IssueDate.Date, getInvoiceResponse.InvoiceHeader.IssueDate.Date);
             Assert.AreEqual(request.Header.Language, getInvoiceResponse.InvoiceHeader.Language);
             Assert.AreEqual(request.Header.PaymentType, getInvoiceResponse.InvoiceHeader.PaymentType);
+            // TODO: InvoiceTemplate is not returned by the API yet
+            //Assert.AreEqual(request.Header.InvoiceTemplate, getInvoiceResponse.InvoiceHeader.InvoiceTemplate);
+            Assert.AreEqual(getInvoiceResponse.InvoiceHeader.InvoiceTemplate, null);
             Assert.AreEqual(request.Customer.Name, getInvoiceResponse.Customer.Name);
             Assert.AreEqual(request.Customer.CustomerAddress.Country, getInvoiceResponse.Customer.CustomerAddress.Country);
             Assert.AreEqual(request.Customer.CustomerAddress.PostalCode, getInvoiceResponse.Customer.CustomerAddress.PostalCode);

--- a/SzamlazzHuTest/testCreateInvoiceRequest.xml
+++ b/SzamlazzHuTest/testCreateInvoiceRequest.xml
@@ -64,6 +64,7 @@
         <szamlaszamElotag></szamlaszamElotag>
         <!-- One of the prefixes from the invoice pad menu  -->
         <fizetve>false</fizetve>
+		<szamlaSablon>Szla8cm</szamlaSablon>
     </fejlec>
     <elado>
         <!-- Details of the merchant-->


### PR DESCRIPTION
Added support to change the default invoice template.

According xsd scheme snippet 

```
<complexType name="fejlecTipus">
        <sequence>
...
<element name="szamlaSablon" type="string" maxOccurs="1" minOccurs="0"></element>       <!-- Codomain: 'SzlaMost' | 'SzlaAlap' | 'SzlaNoEnv' | 'Szla8cm' | 'SzlaTomb' | 'SzlaFuvarlevelesAlap'-->
...
    </sequence>
</complexType>
```

(src: https://docs.szamlazz.hu/#xsd-scheme-compliance)