### PR TITLE
Fix missing escaping for array elements

### DIFF
--- a/SzamlazzHuSDK/Xml/XMLRenderer.cs
+++ b/SzamlazzHuSDK/Xml/XMLRenderer.cs
@@ -57,18 +57,25 @@ public class XMLRenderer
         return jObj.ToObject<T>();
     }
 
-    private static void EscapeJson(JObject jObj)
+    private static void EscapeJson(JToken token)
     {
-        foreach (var prop in jObj.Properties())
+        if (token.Type == JTokenType.Object)
         {
-            if (prop.Value.Type == JTokenType.String)
+            foreach (var property in ((JObject)token).Properties())
             {
-                prop.Value = SecurityElement.Escape(prop.Value.ToString());
+                EscapeJson(property.Value);
             }
-            else if (prop.Value.Type == JTokenType.Object)
+        }
+        else if (token.Type == JTokenType.Array)
+        {
+            foreach (var item in token.Children())
             {
-                EscapeJson((JObject)prop.Value);
+                EscapeJson(item);
             }
+        }
+        else if (token.Type == JTokenType.String)
+        {
+            token.Replace(JValue.CreateString(SecurityElement.Escape(token.ToString())));
         }
     }
 

--- a/SzamlazzHuTest/InvoiceTest.cs
+++ b/SzamlazzHuTest/InvoiceTest.cs
@@ -162,7 +162,7 @@ public class InvoiceTest
         request.Customer.Comment = "Call extension 214 from the reception";
         request.Items = new List<InvoiceItem> {
             new InvoiceItem {
-                Name = "Elado izé",
+                Name = "Elado izé & bizé",
                 Quantity = 1,
                 UnitOfQuantity = "db",
                 UnitPrice = 10000,

--- a/SzamlazzHuTest/testCreateInvoiceRequest.xml
+++ b/SzamlazzHuTest/testCreateInvoiceRequest.xml
@@ -123,7 +123,7 @@
         <!-- items on invoice -->
         <tetel>
             <!-- item 1 -->
-            <megnevezes>Elado izé</megnevezes>
+            <megnevezes>Elado izé &amp; bizé</megnevezes>
             <!-- name -->
             <mennyiseg>1.00</mennyiseg>
             <!-- quantity -->


### PR DESCRIPTION
`EscapeJson` doesn't iterate over arrays so all the tokens inside arrays aren't escaped. The PR ensures that arrays are accounted for and they are escaped as expected.